### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/src/openapi-mcp.py
+++ b/src/openapi-mcp.py
@@ -309,9 +309,10 @@ def run_sse_app(mcp_instance: FastMCP):
                     "server_name": mcp_instance.server_name
                 }
             except Exception as e:
+                logging.error("Exception occurred: %s", str(e))
                 response = {
                     "jsonrpc": "2.0",
-                    "error": {"code": -32000, "message": str(e)},
+                    "error": {"code": -32000, "message": "An internal error has occurred"},
                     "id": req_id,
                     "server_name": mcp_instance.server_name
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/gujord/OpenAPI-MCP/security/code-scanning/1](https://github.com/gujord/OpenAPI-MCP/security/code-scanning/1)

To fix the problem, we should replace the detailed error message with a generic one when sending responses to the client. The detailed error message should be logged on the server for debugging purposes. This approach ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

1. Modify the exception handling block to log the detailed error message.
2. Replace the detailed error message in the response with a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
